### PR TITLE
Remove `---` from end of configmaps

### DIFF
--- a/rstudio/templates/configs-rstudio.yaml
+++ b/rstudio/templates/configs-rstudio.yaml
@@ -20,4 +20,3 @@ data:
     {{- $entry.contents | nindent 8 }}
   {{- end -}}
   {{- end -}}
----


### PR DESCRIPTION
This might be helm version specific, but it seems that it is sometimes appending the three `---` to the configmap value itself, although the indentation should make that not happen. In any case, since it's a single resource in the file, there is no harm in removing it.