### PR TITLE
Revert "Add gatekeeper auth (#8)"

### DIFF
--- a/rstudio/templates/deployment.yaml
+++ b/rstudio/templates/deployment.yaml
@@ -4,16 +4,6 @@ metadata:
   name: {{ include "rstudio.fullname" . }}
   labels:
     {{- include "rstudio.labels" . | nindent 4 }}
-  annotations:
-    authproxy.stakater.com/enabled: "true"
-    authproxy.stakater.com/source-service-name: {{ .Release.Name }}-service
-    authproxy.stakater.com/upstream-url: "http://localhost:8787/"
-    authproxy.stakater.com/client-id: {{ .Values.oidc.client_id }}
-    authproxy.stakater.com/client-secret: {{ .Values.oidc.client_secret }}
-    authproxy.stakater.com/listen: ":80"
-    authproxy.stakater.com/discovery-url: {{ tpl .Values.oidc.discovery_url . }}
-    authproxy.stakater.com/oauth-uri: "{{ .Values.ingress.access_path }}oauth"
-    authproxy.stakater.com/gatekeeper-image: keycloak/keycloak-gatekeeper:7.0.0
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -60,16 +50,16 @@ spec:
               value: "true"
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8787
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /
-              port: 8787
+              port: http
           readinessProbe:
             httpGet:
               path: /
-              port: 8787
+              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/rstudio/templates/ingress.yaml
+++ b/rstudio/templates/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "rstudio.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
 {{- if .Values.ingress.tls }}
@@ -34,7 +34,7 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}-service
+              serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
         {{- end }}
   {{- end }}

--- a/rstudio/templates/service.yaml
+++ b/rstudio/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "rstudio.fullname" . }}-service
+  name: {{ include "rstudio.fullname" . }}
   labels:
     {{- include "rstudio.labels" . | nindent 4 }}
 spec:

--- a/rstudio/values.yaml
+++ b/rstudio/values.yaml
@@ -38,13 +38,9 @@ service:
   port: 80
 
 ingress:
-  access_path: /rstudio/
   enabled: true
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      # This extra rewrite restores the original url because keycloak gatekeeper expects the non-rewritten path
-      rewrite "{{ .Values.ingress.access_path }}oauth(/|$)(.*)" {{ .Values.ingress.access_path }}oauth/$2 break;
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -73,11 +69,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-oidc:
-  client_id: "rstudio"
-  client_secret: "some_secret"
-  discovery_url: "http://cloudman-keycloak-http.cloudman.svc.cluster.local/auth/realms/master"
 
 persistence:
   enabled: true


### PR DESCRIPTION
This reverts commit ca9f11bd6aababca38047c82abf628941f330904.
It appears that there's something going on in the interaction between rstudio and gatekeeper that results in http 415 errors.